### PR TITLE
fix dsn generation when NUL/0x0 character encountered

### DIFF
--- a/src/main/java/org/nhindirect/common/mail/dsn/impl/DefaultDSNFailureTextBodyPartGenerator.java
+++ b/src/main/java/org/nhindirect/common/mail/dsn/impl/DefaultDSNFailureTextBodyPartGenerator.java
@@ -111,7 +111,8 @@ public class DefaultDSNFailureTextBodyPartGenerator implements DSNFailureTextBod
 		while (originalMessageHeaders.hasMoreElements()) 
 		{
 		    Header h = originalMessageHeaders.nextElement();
-		    sb.append(StringEscapeUtils.escapeHtml4(h.getName() + ": " + h.getValue()));
+		    // use escapeXml10 vs escapeHtml4 for its NUL character removing capabilities
+		    sb.append(StringEscapeUtils.escapeXml10(h.getName() + ": " + h.getValue()));
 		    sb.append("<br/>");
 		}
 		return sb.toString();

--- a/src/test/java/org/nhindirect/common/mail/dsn/DNSGenerator_CreateDSNMessageTest.java
+++ b/src/test/java/org/nhindirect/common/mail/dsn/DNSGenerator_CreateDSNMessageTest.java
@@ -1,17 +1,22 @@
 package org.nhindirect.common.mail.dsn;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import javax.mail.Address;
+import javax.mail.Header;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 
 import org.junit.Test;
 import org.nhindirect.common.mail.MailStandard;
@@ -61,5 +66,47 @@ public class DNSGenerator_CreateDSNMessageTest
 		assertTrue( MailStandard.getHeader(dsnMessage, MailStandard.Headers.Subject).startsWith("Not Delivered:"));
 		assertTrue(!MailStandard.getHeader(dsnMessage, MailStandard.Headers.Date).isEmpty());
 		
+	}
+
+	@Test
+	public void testCreateDSNMessage_createDSNMessageWithOriginalHeaders() throws Exception
+	{
+		final DSNGenerator dsnGenerator = new DSNGenerator("Not Delivered:");
+		
+		final DSNRecipientHeaders dsnRecipHeaders = 
+				new DSNRecipientHeaders(DSNAction.FAILED, 
+						DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.UNDEFINED_STATUS), new InternetAddress("ah4626@test.com"));
+		
+		final List<DSNRecipientHeaders> dsnHeaders = new ArrayList<DSNRecipientHeaders>();
+		dsnHeaders.add(dsnRecipHeaders);
+		
+		final String originalMessageId = UUID.randomUUID().toString();
+		final DSNMessageHeaders messageDSNHeaders = new DSNMessageHeaders("DirectJUNIT", originalMessageId, MtaNameType.DNS);
+		
+		List<Address> faileRecips = new ArrayList<Address>();
+		faileRecips.add(new InternetAddress("ah4626@test.com"));
+		
+		List<Header> originalMessageHeaders = new ArrayList<Header>();
+		originalMessageHeaders.add(new Header("Date", "Tue, 11 Jun 2015 02:43:38 -0500 (CDT)"));
+		originalMessageHeaders.add(new Header("From", "\"Smith, John\" <from@test.com>"));
+		originalMessageHeaders.add(new Header("To", "\"Ben & Jerry\" <benandjerry@test.com>"));
+		originalMessageHeaders.add(new Header("Subject", "subject \0goes here")); // this subject contains a NUL character, which should get removed
+		
+		final DefaultDSNFailureTextBodyPartGenerator textGenerator = new DefaultDSNFailureTextBodyPartGenerator("", "%headers_tag%", "",
+				"", "", HumanReadableTextAssemblerFactory.getInstance());
+		
+		
+		
+		final MimeBodyPart textBodyPart = textGenerator.generate(new InternetAddress("gm2552@test.com"), faileRecips, Collections.enumeration(originalMessageHeaders));
+		
+		MimeMessage dsnMessage = dsnGenerator.createDSNMessage(new InternetAddress("gm2552@test.com"), "test", new InternetAddress("postmaster@test.com"), 
+				dsnHeaders, messageDSNHeaders, textBodyPart);
+		
+		assertNotNull(dsnMessage);
+		MimeBodyPart htmlBodyPart = (MimeBodyPart) ((MimeMultipart) dsnMessage.getContent()).getBodyPart(0);
+		String htmlContent = (String) htmlBodyPart.getContent();
+		assertThat(htmlContent, containsString("subject goes here")); // NUL is removed
+		assertThat(htmlContent, containsString("Ben &amp; Jerry")); // ampersand is encoded
+		assertThat(htmlContent, containsString("&lt;from@test.com&gt;")); // <> are encoded
 	}
 }


### PR DESCRIPTION
This resolves an issue where a NUL character in the original message headers can cause DSN message generation to fail in message monitor.