### PR TITLE
Releasing 8.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>direct-common</artifactId>    
     <name>Direct Project common APIs</name>
-    <version>8.1.0</version>
+    <version>8.2.0-SNAPSHOT</version>
     <description>Direct Project common APIs.  Includes instrumentation, auditing, and other utility APIs</description>
     <inceptionYear>2010</inceptionYear>
     <url>http://api.nhindirect.org/x/www/api.nhindirect.org/java/site/direct-common/${project.version}</url> 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>direct-common</artifactId>    
     <name>Direct Project common APIs</name>
-    <version>8.1.2-SNAPSHOT</version>
+    <version>8.1.2</version>
     <description>Direct Project common APIs.  Includes instrumentation, auditing, and other utility APIs</description>
     <inceptionYear>2010</inceptionYear>
     <url>http://api.nhindirect.org/x/www/api.nhindirect.org/java/site/direct-common/${project.version}</url> 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>direct-common</artifactId>    
     <name>Direct Project common APIs</name>
-    <version>8.2.0-SNAPSHOT</version>
+    <version>8.1.2-SNAPSHOT</version>
     <description>Direct Project common APIs.  Includes instrumentation, auditing, and other utility APIs</description>
     <inceptionYear>2010</inceptionYear>
     <url>http://api.nhindirect.org/x/www/api.nhindirect.org/java/site/direct-common/${project.version}</url> 

--- a/src/main/java/org/nhindirect/common/crypto/impl/StaticCachedPKCS11TokenKeyStoreProtectionManager.java
+++ b/src/main/java/org/nhindirect/common/crypto/impl/StaticCachedPKCS11TokenKeyStoreProtectionManager.java
@@ -69,8 +69,15 @@ public class StaticCachedPKCS11TokenKeyStoreProtectionManager extends StaticPKCS
 			// some HSMs only store references to the keys in these objects and 
 			// and still have to go back to the HSM to pull the actual key data
 			// create a key object from the encoded data
-			keystoreProtectionKey = new SecretKeySpec(keystoreProtectionKey.getEncoded(), "");
-			privateKeyProtectionKey = new SecretKeySpec(privateKeyProtectionKey.getEncoded(), "");
+			
+			System.out.print("keystoreProtectionKey is null: " + (keystoreProtectionKey.getEncoded() != null));
+			System.out.print("privateKeyProtectionKey is null: " + (privateKeyProtectionKey.getEncoded() != null));
+			
+			if (keystoreProtectionKey.getEncoded() != null)
+				keystoreProtectionKey = new SecretKeySpec(keystoreProtectionKey.getEncoded(), "");
+			
+			if (privateKeyProtectionKey.getEncoded() != null)
+				privateKeyProtectionKey = new SecretKeySpec(privateKeyProtectionKey.getEncoded(), "");
 			
 			
 			

--- a/src/main/java/org/nhindirect/common/crypto/tools/PKCS11SecretKeyManager.java
+++ b/src/main/java/org/nhindirect/common/crypto/tools/PKCS11SecretKeyManager.java
@@ -6,10 +6,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.security.Security;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.nhindirect.common.crypto.MutableKeyStoreProtectionManager;
 import org.nhindirect.common.crypto.exceptions.CryptoException;
 import org.nhindirect.common.crypto.impl.BootstrappedPKCS11Credential;
@@ -31,10 +33,17 @@ public class PKCS11SecretKeyManager
 	protected static String pkcs11ProviderCfg = null;
 	protected static String keyStoreConfigFile = null;
 	
+	static {
+		Security.addProvider(new BouncyCastleProvider());
+	}
+	
 	public static void main(String[] argv)
 	{     
 		String[] passArgs = null;
 
+		// make sure bouncy castle is initialized
+		
+		
 		
 		// need to check if there is a configuration for the PKCS11
 		// provider... if not, assume the JVM has already been configured for one

--- a/src/main/java/org/nhindirect/common/crypto/tools/commands/PKCS11Commands.java
+++ b/src/main/java/org/nhindirect/common/crypto/tools/commands/PKCS11Commands.java
@@ -38,21 +38,21 @@ import javax.security.auth.x500.X500Principal;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.asn1.ASN1EncodableVector;
-import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
-import org.bouncycastle.asn1.x509.Attribute;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
-import org.bouncycastle.asn1.x509.X509Extensions;
-import org.bouncycastle.asn1.x509.X509ExtensionsGenerator;
 import org.bouncycastle.crypto.prng.VMPCRandomGenerator;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
 import org.bouncycastle.jce.X509Principal;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
 import org.nhindirect.common.crypto.MutableKeyStoreProtectionManager;
 import org.nhindirect.common.crypto.WrappableKeyProtectionManager;
@@ -610,7 +610,7 @@ public class PKCS11Commands
 			// create the CSR
 			
 			//  create the extensions that we want
-			final X509ExtensionsGenerator extsGen = new X509ExtensionsGenerator();
+	        final ExtensionsGenerator extsGen = new ExtensionsGenerator();
 			
 			// Key Usage
 			int usage;
@@ -621,32 +621,23 @@ public class PKCS11Commands
 			else
 				usage = KeyUsage.keyEncipherment | KeyUsage.digitalSignature;
 			
-			extsGen.addExtension(X509Extensions.KeyUsage, true, new KeyUsage(usage));
+			extsGen.addExtension(Extension.keyUsage, true, new KeyUsage(usage));
 			
 			// Subject Alt Name
 	    	int nameType = subjectAltName.contains("@") ? GeneralName.rfc822Name : GeneralName.dNSName;
 	    	final GeneralNames altName = new GeneralNames(new GeneralName(nameType, subjectAltName));
-	    	extsGen.addExtension(X509Extensions.SubjectAlternativeName, false, altName);
+	    	extsGen.addExtension(Extension.subjectAlternativeName, false, altName);
 			
 			// Extended Key Usage
-			final Vector<KeyPurposeId> purposes = new Vector<KeyPurposeId>();
-			purposes.add(KeyPurposeId.id_kp_emailProtection);
-			extsGen.addExtension(X509Extensions.ExtendedKeyUsage, false, new ExtendedKeyUsage(purposes));
+			ExtendedKeyUsage eku = new ExtendedKeyUsage(KeyPurposeId.id_kp_emailProtection);
+			
+			
+			extsGen.addExtension(Extension.extendedKeyUsage, false, eku);
 			
 			// Basic constraint
 			final BasicConstraints bc = new BasicConstraints(false);
-			extsGen.addExtension(X509Extensions.BasicConstraints, true, bc);
+			extsGen.addExtension(Extension.basicConstraints, true, bc);
 			
-			// create the extension requests
-			final X509Extensions exts = extsGen.generate();
-			
-	        final ASN1EncodableVector attributes = new ASN1EncodableVector();
-	        final Attribute attribute = new Attribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
-	                new DERSet(exts.toASN1Primitive()));
-	        
-	        attributes.add(attribute);
-	        
-	        final DERSet requestedAttributes = new DERSet(attributes);
 	        
 			// create the DN
 			final StringBuilder dnBuilder = new StringBuilder("CN=").append(commonName);
@@ -656,16 +647,20 @@ public class PKCS11Commands
 			
 			final X500Principal subjectPrin = new X500Principal(dnBuilder.toString());
 			
-			final X509Principal xName = new X509Principal(true, subjectPrin.getName());
+			//final X509Principal xName = new X509Principal(true, subjectPrin.getName());
+			PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(subjectPrin, storedCert.getPublicKey());
+			builder.setAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extsGen.generate());
+			
+			JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
+			ContentSigner signer = csBuilder.build(privKey);
 			
 			// create the CSR
-			final PKCS10CertificationRequest request = new PKCS10CertificationRequest("SHA256WITHRSA", xName, storedCert.getPublicKey(), 
-			        requestedAttributes, privKey, ks.getProvider().getName());
+
 			
-			final byte[] encodedCSR = request.getEncoded();
+			final byte[] encodedCSR = builder.build(signer).getEncoded();
 			
 			final String csrString = "-----BEGIN CERTIFICATE REQUEST-----\r\n"  + Base64.encodeBase64String(encodedCSR) 
-			+ "-----END CERTIFICATE REQUEST-----";
+			+ "\r\n-----END CERTIFICATE REQUEST-----";
 			
 			final File csrFile = new File(alias + "-CSR.pem");
 			FileUtils.writeStringToFile(csrFile, csrString);

--- a/src/test/java/org/nhindirect/common/crypto/impl/PKCS11OperationTests.java
+++ b/src/test/java/org/nhindirect/common/crypto/impl/PKCS11OperationTests.java
@@ -65,7 +65,7 @@ public class PKCS11OperationTests
 		{
 			final KeyStore ks = KeyStore.getInstance("PKCS11");
 			
-			ks.load(null, "1Kingpuff".toCharArray());
+			ks.load(null, "1Kingpuff!".toCharArray());
 			
 			final Enumeration<String> aliases = ks.aliases();
 			
@@ -117,7 +117,7 @@ public class PKCS11OperationTests
 		
 		if (!StringUtils.isEmpty(pkcs11ProvName))
 		{
-			final PKCS11Credential cred = new BootstrappedPKCS11Credential("1Kingpuff");
+			final PKCS11Credential cred = new BootstrappedPKCS11Credential("1Kingpuff!");
 			final StaticPKCS11TokenKeyStoreProtectionManager mgr = 
 					new StaticPKCS11TokenKeyStoreProtectionManager(cred, "KeyStoreProtKey", "PrivKeyProtKey");
 			
@@ -136,10 +136,10 @@ public class PKCS11OperationTests
 			 * wrap it on the HSM.
 			 */
 			final KeyStore store = KeyStore.getInstance("pkcs12");
-			store.load(FileUtils.openInputStream(new File("./src/test/resources/certs/gm2552encrypted.p12")), "1kingpuff".toCharArray());
+			store.load(FileUtils.openInputStream(new File("./src/test/resources/certs/gm2552encrypted.p12")), "1Kingpuff!".toCharArray());
 			// there should only be on entry
 			final String alias = store.aliases().nextElement();
-			final PrivateKey entry = (PrivateKey)store.getKey(alias, "1kingpuff".toCharArray());
+			final PrivateKey entry = (PrivateKey)store.getKey(alias, "1Kingpuff!".toCharArray());
 			
 			/*
 			 * 3. "Wrap" the private using secret key and AES128 encryption and write it to a file.  The encryption is done

--- a/src/test/java/org/nhindirect/common/util/TestUtils.java
+++ b/src/test/java/org/nhindirect/common/util/TestUtils.java
@@ -25,7 +25,7 @@ public class TestUtils
 					if (callback instanceof PasswordCallback)
 					{		
 						
-						 ((PasswordCallback)callback).setPassword("1Kingpuff".toCharArray());
+						 ((PasswordCallback)callback).setPassword("1Kingpuff!".toCharArray());
 					
 					}
 				}


### PR DESCRIPTION
Update PKCS11 crypto implementation: refactor CSR generation to use modern Bouncy Castle API, add provider initialization, improve key handling with null checks, and correct test passwords